### PR TITLE
Merge legend and poly.line bugfixes into master

### DIFF
--- a/R/phonR.R
+++ b/R/phonR.R
@@ -306,12 +306,24 @@ plotVowels <- function(f1, f2, vowel=NULL, group=NULL,
     ## color: use default pallete if none specified and pretty=FALSE
     if (!"col" %in% names(exargs)) exargs$col <- palette()
     ## linetypes & plotting characters
-    if (!"lty" %in% names(exargs)) exargs$lty <- seq_len(num.sty)
+    if (!"lty" %in% names(exargs)) {
+        if (all(var.col.by==as.numeric(factor(group, levels=unique(group))))) {
+            exargs$lty <- seq_len(num.col)
+        } else {
+            exargs$lty <- seq_len(num.sty)
+        }
+    }
     if (!"pch" %in% names(exargs)) exargs$pch <- seq_len(num.sty)
     if (!"lwd" %in% names(exargs)) exargs$lwd <- par("lwd")
     ## recycle user-specified colors to the length we need
     if (vary.col) exargs$col <- rep(exargs$col, length.out=num.col)[var.col.by]
-    if (vary.sty) exargs$lty <- rep(exargs$lty, length.out=num.sty)[var.sty.by]
+    if (all(var.col.by==as.numeric(factor(group, levels=unique(group))))) {
+        exargs$lty <- rep(exargs$lty, length.out=num.col)[var.col.by]
+        # print("var.col.by==group")
+    } else {
+        exargs$lty <- rep(exargs$lty, length.out=num.sty)[var.sty.by]
+        # print("var.sty.by==group")
+    }
     if (vary.sty) exargs$pch <- rep(exargs$pch, length.out=num.sty)[var.sty.by]
     ## set defaults for token and mean plotting characters
     if (is.null(pch.tokens)) pch.t <- exargs$pch
@@ -378,9 +390,15 @@ plotVowels <- function(f1, f2, vowel=NULL, group=NULL,
     ## polygon colors
     if (poly.line) {
         if ("lty" %in% names(poly.args)) {
-            poly.args$lty <- rep(poly.args$lty, length.out=num.sty)
-            if (vary.sty) poly.line.sty <- poly.args$lty[var.sty.by]
-            else          poly.line.sty <- poly.args$lty
+            if (all(var.sty.by==as.numeric(factor(group, levels=unique(group))))) {
+                poly.args$lty <- rep(poly.args$lty, length.out=num.sty)
+                poly.line.sty <- poly.args$lty[var.sty.by]
+            } else if (all(var.col.by==as.numeric(factor(group, levels=unique(group))))) {
+                poly.args$lty <- rep(poly.args$lty, length.out=num.col)
+                poly.line.sty <- poly.args$lty[var.col.by]
+            } else {
+                poly.line.sty <- poly.args$lty
+            }
             poly.args$lty <- NULL
         } else {
             poly.line.sty <- exargs$lty
@@ -448,6 +466,7 @@ plotVowels <- function(f1, f2, vowel=NULL, group=NULL,
     d <- data.frame(f1=f1, f2=f2, v=v, gf=factor(gf, levels=unique(gf)),
                     col.tokens=col.tokens, col.means=col.means,
                     style=var.sty.by, lty=exargs$lty, lwd=exargs$lwd,
+                    # style=var.sty.by, lty=poly.line.sty, lwd=exargs$lwd,
                     ellipse.fill.col=ellipse.fill.col,
                     ellipse.line.col=ellipse.line.col,
                     ellipse.line.sty=ellipse.line.sty,

--- a/R/phonR.R
+++ b/R/phonR.R
@@ -466,7 +466,6 @@ plotVowels <- function(f1, f2, vowel=NULL, group=NULL,
     d <- data.frame(f1=f1, f2=f2, v=v, gf=factor(gf, levels=unique(gf)),
                     col.tokens=col.tokens, col.means=col.means,
                     style=var.sty.by, lty=exargs$lty, lwd=exargs$lwd,
-                    # style=var.sty.by, lty=poly.line.sty, lwd=exargs$lwd,
                     ellipse.fill.col=ellipse.fill.col,
                     ellipse.line.col=ellipse.line.col,
                     ellipse.line.sty=ellipse.line.sty,
@@ -983,6 +982,7 @@ plotVowels <- function(f1, f2, vowel=NULL, group=NULL,
                 } else if (!(length(unique(poly.line.sty)) == 1 &&
                                  poly.line.sty[1] == 0)) {
                     legend.lty <- sapply(bym, function(i) unique(i$poly.line.sty))
+                    # print(legend.lty)
                 } else {
                     legend.lty <- unique(hull.line.sty)
                 }
@@ -998,14 +998,21 @@ plotVowels <- function(f1, f2, vowel=NULL, group=NULL,
                 }
             }
             ## handle lty specially; needed for both style & color
+            # print(legend.lty)
+            ##NEED TO DETERMINE WHICH IS THE LTY GROUP AND THEN APPLY NAS
             if (!is.null(legend.lty)) {
                 if (!length(legend.style.lab)) {
                     legend.lty <- rep(legend.lty,
                                       length.out=length(legend.col.lab))
                 } else if (length(legend.col.lab)) {
-                    legend.lty <- c(legend.lty, rep(NA, length(legend.col.lab)))
+                    if (all(var.col.by==as.numeric(factor(group,levels=unique(group))))) {
+                        legend.lty <- c(rep(NA, length(legend.style.lab)), legend.lty)
+                    } else {
+                        legend.lty <- c(legend.lty, rep(NA, length(legend.col.lab)))
+                    }
                 }
             }
+            # print(legend.lty)
             ## reconcile
             if (identical(legend.style.lab, legend.col.lab)) {
                 legend.lab <- legend.col.lab
@@ -1066,6 +1073,7 @@ plotVowels <- function(f1, f2, vowel=NULL, group=NULL,
             }
             ## draw legend
             do.call(legend, legend.args)
+            # return(legend.args)
         }
     }
 

--- a/R/phonR.R
+++ b/R/phonR.R
@@ -319,10 +319,8 @@ plotVowels <- function(f1, f2, vowel=NULL, group=NULL,
     if (vary.col) exargs$col <- rep(exargs$col, length.out=num.col)[var.col.by]
     if (all(var.col.by==as.numeric(factor(group, levels=unique(group))))) {
         exargs$lty <- rep(exargs$lty, length.out=num.col)[var.col.by]
-        # print("var.col.by==group")
     } else {
         exargs$lty <- rep(exargs$lty, length.out=num.sty)[var.sty.by]
-        # print("var.sty.by==group")
     }
     if (vary.sty) exargs$pch <- rep(exargs$pch, length.out=num.sty)[var.sty.by]
     ## set defaults for token and mean plotting characters
@@ -489,10 +487,8 @@ plotVowels <- function(f1, f2, vowel=NULL, group=NULL,
         byd <- list(d=d)
     } else if (all(var.col.by==as.numeric(factor(group, levels=unique(group))))) {
         byd <- by(d, d[c("gf","v")], identity)
-        # print("gf-v")
     } else {
         byd <- by(d, d[c("v", "gf")], identity)
-        # print("v-gf")
     }
     ## dataframe of means. at this point each element of "byd" should have
     ## exactly 1 vowel and 1 grouping factor (gf) value
@@ -982,7 +978,6 @@ plotVowels <- function(f1, f2, vowel=NULL, group=NULL,
                 } else if (!(length(unique(poly.line.sty)) == 1 &&
                                  poly.line.sty[1] == 0)) {
                     legend.lty <- sapply(bym, function(i) unique(i$poly.line.sty))
-                    # print(legend.lty)
                 } else {
                     legend.lty <- unique(hull.line.sty)
                 }
@@ -998,8 +993,6 @@ plotVowels <- function(f1, f2, vowel=NULL, group=NULL,
                 }
             }
             ## handle lty specially; needed for both style & color
-            # print(legend.lty)
-            ##NEED TO DETERMINE WHICH IS THE LTY GROUP AND THEN APPLY NAS
             if (!is.null(legend.lty)) {
                 if (!length(legend.style.lab)) {
                     legend.lty <- rep(legend.lty,
@@ -1012,7 +1005,6 @@ plotVowels <- function(f1, f2, vowel=NULL, group=NULL,
                     }
                 }
             }
-            # print(legend.lty)
             ## reconcile
             if (identical(legend.style.lab, legend.col.lab)) {
                 legend.lab <- legend.col.lab
@@ -1036,6 +1028,14 @@ plotVowels <- function(f1, f2, vowel=NULL, group=NULL,
                     legend.brd <- legend.bgf
                     legend.col <- c(rep(par("fg"), length(legend.style.lab)),
                                     legend.col)
+                ## handle case: col.by.vowel and poly.line & sty by group
+                } else if (vary.sty && vary.col && is.null(legend.bgf) && poly.line &&
+                           all(var.sty.by==as.numeric(factor(group,levels=unique(group))))) {
+                    legend.col <- c(rep(par("fg"), length(legend.style.lab)),
+                                    legend.col)
+                    legend.bgf <- c(rep(NA, length(legend.style.lab)),
+                                    legend.col[-(1:length(legend.style.lab))])
+                    legend.brd <- legend.bgf
                 ## handle other cases
                 } else {
                     nas <- rep(NA, length(legend.style.lab))

--- a/R/phonR.R
+++ b/R/phonR.R
@@ -469,8 +469,12 @@ plotVowels <- function(f1, f2, vowel=NULL, group=NULL,
     }
     if (is.null(vowel) && is.null(group)) {
         byd <- list(d=d)
+    } else if (all(var.col.by==as.numeric(factor(group, levels=unique(group))))) {
+        byd <- by(d, d[c("gf","v")], identity)
+        # print("gf-v")
     } else {
         byd <- by(d, d[c("v", "gf")], identity)
+        # print("v-gf")
     }
     ## dataframe of means. at this point each element of "byd" should have
     ## exactly 1 vowel and 1 grouping factor (gf) value
@@ -1053,6 +1057,7 @@ plotVowels <- function(f1, f2, vowel=NULL, group=NULL,
     if (output != "screen") dev.off()
     ## reset graphical parameters to defaults
     par(op)
+    # return(list(byd, group, var.col.by, legend.col))
 }
 
 

--- a/tests/test-legend.R
+++ b/tests/test-legend.R
@@ -1,0 +1,21 @@
+#!/usr/bin/env R
+
+source("../R/phonR.R")
+load("../data/indoVowels.rda")
+
+colorby <- rep(c("vowel", "subj", "gender"), each=3)
+styleby <- rep(c("vowel", "subj", "gender"), times=3)
+grouping <- c("subj", "gender", NA, "gender", NA, "subj", NA, "subj", "gender")
+
+
+cairo_pdf("test-legend-master.pdf", width=16, height=16, pointsize=12, 
+          family="Charis SIL")
+    par(mfrow=c(3, 3))
+    mapply(FUN=function(cb, sb, gr) {
+        title <- paste0("var.col.by=", cb, ", var.sty.by=", sb, ", group=", gr, collapse="")
+        plotVowels(indo$f1, indo$f2, indo$vowel, group=indo[[gr]], 
+                 var.col.by=indo[[cb]], var.sty.by=indo[[sb]], pretty=TRUE,
+                 plot.tokens=TRUE, plot.means=FALSE, ellipse.line=TRUE, 
+                 legend.kwd='bottomright', main=title)
+        }, colorby, styleby, grouping)
+dev.off()


### PR DESCRIPTION
Fixed the following bugs with legend and poly.line:
1. When defining both vowel and group (i.e., vowel!=NULL & group!=NULL), setting plot.tokens=TRUE and plot.means=FALSE, and coloring by group, the wrong colors show up in the legend (regardless of values of var.sty.by or pretty); the right colors show up under the same conditions if coloring by vowel.
2. There's a similar issue for poly.line=TRUE: if the style variable is vowels and the color variable is something else (i.e., the poly.line connects vowels of the same color), all linetypes will always be the first value of poly.args$lty/exargs$lty or, if both are NULL, solid (lty=1).
3. Under the same circumstances, the wrong linetypes show up in the legend
4. When poly.line=TRUE, the color variable is vowels, and the style variable is something else, colored boxes don't show up next to vowels in the legend.
